### PR TITLE
styling on github button

### DIFF
--- a/app/assets/stylesheets/activities.css.scss
+++ b/app/assets/stylesheets/activities.css.scss
@@ -23,4 +23,9 @@ section.activity-details {
       @extend .pull-right;
     }
   }
+  .fa-1 {
+    font-size: 1.7em;
+    line-height: 0.75em;
+    vertical-align: -15%;
+  }
 }

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -27,8 +27,7 @@ section.activity-details
       .form-group
         .input-group
           = link_to @activity.gist_url, { target: "blank", class: "input-group-addon" }
-            i.fa.fa-github
-            | &nbsp;Original 
+            i.fa.fa-github.fa-1
           span.form-control
             = @activity.gist_url
 


### PR DESCRIPTION
- Removed "original" that appeared before Github button.
- Updated button styling. 

https://trello.com/c/ne8lEpl5
