### PR TITLE
Weekend Time/57 -- Don't display time on weekends

### DIFF
--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -6,5 +6,17 @@ class DaysController < ApplicationController
     @activities = Activity.chronological.for_day(day)
   end
 
+  protected
 
+  def time_estimate start, finish
+    result = finish - start
+
+    if result <= 60
+      result.to_s << " Min"
+    else
+      result = (((result / 60.00) *2).round / 2.0).to_s
+      result.to_i > 1 ? result << " Hours" : result << " Hour"
+    end
+  end
+  helper_method :time_estimate
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -21,7 +21,7 @@ class Activity < ActiveRecord::Base
       duration_minutes = 0
     end
 
-    return (hours + duration_hours) * 100 + (minutes + duration_minutes)
+    (hours + duration_hours) * 100 + (minutes + duration_minutes)
   end
 
   def update_instructions_from_gist

--- a/app/views/assignments/_assignment.html.slim
+++ b/app/views/assignments/_assignment.html.slim
@@ -2,11 +2,14 @@
   .pull-left.icon
     i.fa.fa-edit
   .pull-left.time
-    = integer_time_to_s assignment.start_time
+    = integer_time_to_s assignment.start_time unless params[:number].chars.last == 'e'
     br
-    | to
+    - unless params[:number].chars.last == 'e'
+      | to
+    - else
+      = time_estimate assignment.start_time, assignment.end_time
     br
-    = integer_time_to_s assignment.end_time
+    = integer_time_to_s assignment.end_time unless params[:number].chars.last == 'e'
   .pull-left.name
     = link_to assignment.name, day_activity_path(day, assignment)
   .clearfix

--- a/app/views/homeworks/_homework.html.slim
+++ b/app/views/homeworks/_homework.html.slim
@@ -2,11 +2,14 @@
   .pull-left.icon
     i.fa.fa-moon-o
   .pull-left.time
-    = integer_time_to_s homework.start_time
+    = integer_time_to_s homework.start_time  unless params[:number].chars.last == 'e'
     br
-    | to
+    - unless params[:number].chars.last == 'e'
+      | to
+    - else
+      = time_estimate homework.start_time, homework.end_time
     br
-    = integer_time_to_s homework.end_time
+    = integer_time_to_s homework.end_time unless params[:number].chars.last == 'e'
   .pull-left.name
     = link_to homework.name, day_activity_path(day, homework)
   .clearfix


### PR DESCRIPTION
[Trello Card](https://trello.com/c/HEihTyLf/57-weekend-schedule-don-t-display-times)

Students can choose to spread out the work over Sat/Sun as they please.

start_time will still be specified to facilitate ordering. The estimated duration should be displayed in it's place instead
