### PR TITLE
Weekend Time/57 -- Don't display time on weekends

### DIFF
--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -14,6 +14,15 @@ module ActivitiesHelper
     number_with_precision (duration.to_f / 60), precision: 2, strip_insignificant_zeros: true
   end
 
+  def duration activity
+    duration = activity.duration
+    duration < 60 ? duration.to_s << 'min' : duration_in_hours(duration) << "h"
+  end
+
+  def weekend?
+    !!(day =~ /(?<=w\d)e$/)
+  end
+
   def icon_for(activity)
     case activity.type.downcase
     when "assignment"
@@ -30,4 +39,3 @@ module ActivitiesHelper
   end
 
 end
-

--- a/app/views/activities/_activity.html.slim
+++ b/app/views/activities/_activity.html.slim
@@ -2,11 +2,14 @@ div class=("#{activity.type.downcase} " + 'activity')
   .pull-left.icon
     i class=(icon_for(activity))
   .pull-left.time
-    = integer_time_to_s activity.start_time
+    = integer_time_to_s activity.start_time unless weekend?
     br
-    | to
+    - unless weekend?
+      | to
+    - else
+     = duration activity 
     br
-    = integer_time_to_s activity.end_time
+    = integer_time_to_s activity.end_time unless weekend?
   .pull-left.name
     = link_to activity.name, day_activity_path(day, activity)
   .clearfix

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -9,17 +9,24 @@ section.activity-details
       .input-group.col-md-3
         span.input-group-addon
           i.fa.fa-clock-o
-          | &nbsp;Time
+          - if weekend?
+            | &nbsp;Duration
+          - else
+            | &nbsp;Time
         span.form-control
-          = integer_time_to_s(@activity.start_time)
-          | &nbsp;to&nbsp;
-          = integer_time_to_s(@activity.end_time)
-          | &nbsp;(
-          = duration_in_hours(@activity.duration)
-          | h)
+          - unless weekend?
+            = integer_time_to_s(@activity.start_time)
+            | &nbsp;to&nbsp;
+            = integer_time_to_s(@activity.end_time)
+            | &nbsp;(
+            = duration_in_hours(@activity.duration)
+            | h)
+          - else
+            = duration_in_hours(@activity.duration)
+            | h
 
   p
-    | Last updated at: 
+    | Last updated at:
     time = format_date_time(@activity.updated_at)
 
   - if @activity.gist_url?


### PR DESCRIPTION
[Trello Card](https://trello.com/c/HEihTyLf/57-weekend-schedule-don-t-display-times)

Students can choose to spread out the work over Sat/Sun as they please.

start_time will still be specified to facilitate ordering. The estimated duration should be displayed in it's place instead

Merge issues came up on [old pull request](https://github.com/lighthouse-labs/laser_shark/pull/55). Created new branch
