### PR TITLE
Feature/104 ability to add lecture notes

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,10 +2,27 @@ class ActivitiesController < ApplicationController
 
   include CourseCalendar # concern
 
+  before_action :require_teacher, only: :update
+
   def show
     @activity = Activity.chronological.for_day(day).find(params[:id])
     @next_activity = @activity.next
     @previous_activity = @activity.previous
+  end
+
+  def update
+    activity = Activity.for_day(day).find(params[:id])
+
+    if params[:update_gist]
+      if params[:update_gist] == "instructions"
+        activity.update_instructions_from_gist
+      elsif params[:update_gist] == "teacher_notes"
+        activity.update_teacher_notes_from_gist
+      else
+        render text: "Invalid update_gist parameter.", status: 500; return
+      end
+      redirect_to day_activity_url(activity.day, activity)
+    end
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :teacher?
 
+  def require_teacher
+    if !teacher?
+      redirect_to(day_path('today'), alert: 'Access not allowed yet!')
+    end
+  end
+
   def cohort
     @cohort ||= current_user.try(:cohort)
     # Teachers can switch to any cohort

--- a/app/controllers/concerns/course_calendar.rb
+++ b/app/controllers/concerns/course_calendar.rb
@@ -4,7 +4,7 @@ module CourseCalendar
   included do
     helper_method :today
     helper_method :day
-    before_filter :allowed_day?
+    before_filter :allowed_day?, only: :show
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -25,15 +25,10 @@ class Activity < ActiveRecord::Base
   end
 
   def update_instructions_from_gist
-    if self.gist_url?
-      github = Github.new
-      gist = github.gists.get gist_id
-      file = gist.files['README.md'] || gist.files.detect { |f| f.first.ends_with?('.md') }.try(:last)
-      if readme = file.try(:content)
-        self.instructions = readme
-        self.save
-      end
-    end
+    return if !self.gist_url?
+    gist = ActivityGist.new(self.gist_url)
+    self.instructions = gist.activity_content
+    self.save
   end
 
   def next
@@ -42,12 +37,6 @@ class Activity < ActiveRecord::Base
 
   def previous
     Activity.where('start_time < ? AND day = ?', self.start_time, self.day).order(start_time: :desc).first
-  end
-
-  protected
-
-  def gist_id
-    self.gist_url.split('/').last
   end
 
 end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -1,3 +1,11 @@
 class Lecture < Activity
+  after_create :update_teacher_notes_from_gist
+
+  def update_teacher_notes_from_gist
+    return if !self.teacher_notes_gist_url?
+    gist = ActivityGist.new(self.teacher_notes_gist_url)
+    self.teacher_notes = gist.activity_content
+    self.save
+  end
 
 end

--- a/app/views/activities/_gist_url_box.html.slim
+++ b/app/views/activities/_gist_url_box.html.slim
@@ -5,6 +5,6 @@
         i.fa.fa-github.fa-1
       span.form-control
         = url
-      - if defined? refresh_url
-        = link_to "Refresh", refresh_url, {class: "input-group-addon", method: "post", remote: true}
+      - if defined? refresh_teacher_notes_button
+        = link_to "Refresh", day_activity_path(activity.day, activity, update_gist: 'teacher_notes'), {class: "input-group-addon", method: "put"}
 

--- a/app/views/activities/_gist_url_box.html.slim
+++ b/app/views/activities/_gist_url_box.html.slim
@@ -1,0 +1,10 @@
+.actions
+  .form-group
+    .input-group
+      = link_to url, { target: "blank", class: "input-group-addon" }
+        i.fa.fa-github.fa-1
+      span.form-control
+        = url
+      - if defined? refresh_url
+        = link_to "Refresh", refresh_url, {class: "input-group-addon", method: "post", remote: true}
+

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -44,6 +44,6 @@ section.activity-details
 
   - if teacher? && @activity.teacher_notes
     h3 = "Teacher Notes"
-    == render 'gist_url_box', url: @activity.teacher_notes_gist_url, refresh_url: "#"
+    == render 'gist_url_box', url: @activity.teacher_notes_gist_url, refresh_teacher_notes_button: true, activity: @activity
     .instructions
       == markdown @activity.teacher_notes

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -28,23 +28,8 @@ section.activity-details
   p
     | Last updated at:
     time = format_date_time(@activity.updated_at)
-
-  - if @activity.gist_url?
-    .actions
-      .form-group
-        .input-group
-          = link_to @activity.gist_url, { target: "blank", class: "input-group-addon" }
-            i.fa.fa-github.fa-1
-          span.form-control
-            = @activity.gist_url
-
-        / br
-        / .input-group
-        /   span.input-group-addon
-        /     | Your
-        /     i.fa.fa-github
-        /   input.form-control type="text" value=@activity.gist_url
-
+  - if @activity.gist_url
+    == render 'gist_url_box', :url => @activity.gist_url
   hr
 
   - if @activity.instructions?
@@ -59,5 +44,6 @@ section.activity-details
 
   - if teacher? && @activity.teacher_notes
     h3 = "Teacher Notes"
+    == render 'gist_url_box', url: @activity.teacher_notes_gist_url, refresh_url: "#"
     .instructions
       == markdown @activity.teacher_notes

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,8 @@ module LaserShark
 
     # Form objects are in app/forms
     config.autoload_paths += Dir[Rails.root.join('app', 'forms', '{**}')]
-
+    # Load classes in lib
+    config.autoload_paths << Rails.root.join('lib')
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ LaserShark::Application.routes.draw do
 
   # CONTENT BROWSING
   resources :days, param: :number, only: [:show] do
-    resources :activities, only: [:show]
+    resources :activities, only: [:show, :update]
   end
 
   resources :cohorts, only: [] do

--- a/db/migrate/20140711224657_activities_add_teacher_notes_gist_url.rb
+++ b/db/migrate/20140711224657_activities_add_teacher_notes_gist_url.rb
@@ -1,0 +1,5 @@
+class ActivitiesAddTeacherNotesGistUrl < ActiveRecord::Migration
+  def change
+    add_column :activities, :teacher_notes_gist_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140708231510) do
+ActiveRecord::Schema.define(version: 20140711224657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20140708231510) do
     t.string   "gist_url"
     t.text     "instructions"
     t.text     "teacher_notes"
+    t.string   "teacher_notes_gist_url"
   end
 
   create_table "cohorts", force: true do |t|

--- a/lib/activity_gist.rb
+++ b/lib/activity_gist.rb
@@ -1,0 +1,37 @@
+class ActivityGist
+
+  attr_accessor :url
+
+  DEFAULT_FILE_NAME = 'README.md'
+
+  def initialize(url)
+    @url = url
+    client = Github.new
+    @gist = client.gists.get(gist_id)
+  end
+
+  # Gists have instructions in markdown format
+  # Typically these are stored in README.md
+  # If there is no README.md, returns the content of the first 
+  # markdown file
+  def activity_content
+    readme = @gist.files[DEFAULT_FILE_NAME]
+    readme ||= files_with_extension('md').try(:first)
+    readme.try(:content)
+  end
+
+  def files
+    @gist.files
+  end
+
+  def files_with_extension(extension)
+    return if !extension.present?
+    results = files.select {|file_name, file| file_name.ends_with?(".#{extension}")}
+    results.values
+  end
+
+  private
+  def gist_id
+    @url.split('/').last
+  end
+end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,5 +1,60 @@
 require 'spec_helper'
 
 describe ActivitiesController do
+  describe "GET #show" do
+    logged_in_user
 
+    before :each do
+      @activity = FactoryGirl.create(:activity, day: 'w1d1')
+    end
+
+    describe "students in the prep course" do
+      it "should be redirected to the prep course" do
+        User.any_instance.stub(:prepping?).and_return('true')
+        get :show, day_number: 'w1d1', id: @activity.id
+        response.should redirect_to(prep_path)
+      end
+    end
+
+  end
+
+  describe "PATCH #update" do
+    describe "teachers" do
+      before :each do
+        login_as FactoryGirl.create(:teacher, uid: 'uid', token: 'token')
+      end
+
+      it "can update lecture notes" do
+        lecture = FactoryGirl.create(:lecture, day: 'w1d1')
+        Lecture.any_instance.should_receive(:update_teacher_notes_from_gist).and_return(true)
+        patch 'update', update_gist: 'teacher_notes', day_number: 'w1d1', id: lecture.id
+        response.should be_success
+      end
+
+      it "can update activity notes" do
+        activity = FactoryGirl.create(:activity, day: 'w1d1')
+        Activity.any_instance.should_receive(:update_instructions_from_gist)
+        patch 'update', update_gist: 'instructions', day_number: 'w1d1', id: activity.id
+        response.should be_success
+      end
+      
+      it "will not allow invalid messages" do
+        activity = FactoryGirl.create(:activity, day: 'w1d1')
+        patch 'update', update_gist: 'doesnt_exist', day_number: 'w1d1', id: activity.id
+        response.should be_error
+      end
+    end
+
+    describe "students" do
+      before :each do
+        @lecture = FactoryGirl.create(:lecture, day: 'w1d1')
+        login_as FactoryGirl.create(:student, uid: 'uid', token: 'token')
+      end
+
+      it "cannot update gists" do
+        patch 'update', update_gist: 'instructions', day_number: 'w1d1', id: @lecture.id
+        response.should be_redirect
+      end
+    end
+  end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -6,5 +6,9 @@ FactoryGirl.define do
     day { "w#{rand(1..8)}d#{rand(1..5)}" }
     start_time { [900, 1100, 1500, 1900, 2200].sample }
     duration { rand(60..180) }
+
+    factory :lecture, class: Lecture, parent: :activity do
+      type "Lecture"
+    end
   end
 end

--- a/spec/lib/activity_gist_spec.rb
+++ b/spec/lib/activity_gist_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+def stub_github_with_files(files)
+  github = double('github')
+  github.stub_chain(:new, :gists, :get).and_return(double(files: files))
+  stub_const("Github", github)
+end
+
+describe ActivityGist do
+  describe "#activity_content" do
+    it "should retrieve the README.md if it exists" do
+      files = {
+        'README.md' => double(content: "Happy happy joy joy!")
+      }
+      stub_github_with_files(files)
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.activity_content.should eq "Happy happy joy joy!"
+    end
+
+    it "should retrieve the README.md if it exists" do
+      files = {
+        'README.md' => double(content: "Contents of README.md"),
+        'example.rb'  => double(content: "Contents of example.rb"),
+        'notes.md'  => double(content: "Contents of notes.md")
+      }
+      stub_github_with_files(files)
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.activity_content.should eq "Contents of README.md"
+    end
+
+    it "should retrieve the first md file if there is no README.md" do
+      files = {
+        'hello.md' => double(content: "Contents of hello.md"),
+        'example.rb'  => double(content: "Contents of example.rb"),
+        'notes.md'  => double(content: "Contents of notes.md")
+      }
+      stub_github_with_files(files)
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.activity_content.should eq "Contents of hello.md"
+    end
+
+    it "should return nil if there are no markdown files" do
+      files = {
+        'example.rb' => double(content: "Contents of example.rb")
+      }
+      stub_github_with_files(files)
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.activity_content.should be_nil
+    end
+  end
+
+  describe "#files_with_extension" do
+    it "should find a file for a given extension" do
+      files = {
+        'hello.md' => double(content: "Contents of hello.md"),
+        'example.rb'  => double(content: "Contents of example.rb"),
+        'notes.md'  => double(content: "Contents of notes.md")
+      }
+      stub_github_with_files(files)
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      md_files = gist.files_with_extension('md')
+      md_files.length.should eq 2
+      md_files.map(&:content).should eql ["Contents of hello.md", "Contents of notes.md"]
+    end
+  end
+
+  describe "internal methods" do
+    before :each do
+      stub_const("Github", double('github').as_null_object) # we are not hitting the API
+    end
+
+    it "should keep track of the gist url" do
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.url.should eq "https://gist.github.com/monicao/d372716cdfbb7e9cf692"
+    end
+
+    it "should extract the gist id from a gist url" do
+      gist = ActivityGist.new("https://gist.github.com/monicao/d372716cdfbb7e9cf692")
+      gist.send(:gist_id).should eq "d372716cdfbb7e9cf692"
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -32,4 +32,17 @@ describe Activity do
     activity.end_time.should eql 1210 
   end
 
+  it "can update the instruction notes" do
+    ActivityGist.any_instance.stub(:initialize)
+    ActivityGist.any_instance.stub(:activity_content).and_return("Here are the instructions")
+    activity = create(:activity, gist_url: "http://gist.github.com/fakej39f3")
+    activity.update_instructions_from_gist
+    expect(activity.instructions).to eq("Here are the instructions")
+  end
+
+  it "should update the teacher notes when the activity is created" do
+    activity = build(:activity, teacher_notes_gist_url: "http://gist.github.com/fakej39f3")
+    activity.should_receive(:update_instructions_from_gist)
+    activity.save!
+  end
 end

--- a/spec/models/lecture_spec.rb
+++ b/spec/models/lecture_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Lecture do
+
+  it "has a valid factory" do
+    expect(build(:lecture)).to be_valid
+  end
+
+  it "should update the teacher notes" do
+    lecture = create(:lecture, teacher_notes_gist_url: "http://gist.github.com/fakej39f3")
+    ActivityGist.any_instance.stub(:initialize)
+    ActivityGist.any_instance.stub(:activity_content).and_return("Here are the instructions")
+    lecture.update_teacher_notes_from_gist
+    expect(lecture.teacher_notes).to eq("Here are the instructions")
+  end
+
+  it "should update the teacher notes when the lecture is created" do
+    lecture = build(:lecture, teacher_notes_gist_url: "http://gist.github.com/fakej39f3")
+    lecture.should_receive(:update_teacher_notes_from_gist)
+    lecture.save!
+  end
+
+end


### PR DESCRIPTION
@kvirani @fourmojocto Tada!

Teachers can see lecture notes written in a gist. 

At the moment you have to use the rails console to add lecture note gists to an activity (or we can use our activities_seed.rb file). Not sure if we want to do this through the UI... LMK

See Trello card for more info:
https://trello.com/c/0JpfV6v0/104-ability-to-add-lecture-notes


