### PR TITLE
add bio text area for all user profiles

### DIFF
--- a/app/forms/registration_form.rb
+++ b/app/forms/registration_form.rb
@@ -8,6 +8,7 @@ class RegistrationForm < Reform::Form
   property :twitter,  		on: :user
   property :skype,  			on: :user
   property :custom_avatar, on: :user
+  property :bio, on: :user
 
   property :completed_registration, on: :user
 

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -29,6 +29,7 @@ div
     = f.input :phone_number
     = f.input :twitter
     = f.input :skype
+    = f.input :bio
 
 
     .form-group

--- a/app/views/registrations/new.html.slim
+++ b/app/views/registrations/new.html.slim
@@ -27,6 +27,7 @@ div
     = f.input :phone_number
     = f.input :twitter
     = f.input :skype
+    = f.input :bio
 
     .form-group
       .col-sm-offset-3.col-sm-9

--- a/app/views/students/index.html.slim
+++ b/app/views/students/index.html.slim
@@ -7,6 +7,7 @@ table.table
       th Email
       th Phone
       th GitHub Username
+      th Bio
       
   tbody
     - @students.each do |student|
@@ -17,4 +18,5 @@ table.table
         td = student.phone_number
         td  
           a href=("https://github.com/#{student.github_username}") = student.github_username
+        td = student.bio
        

--- a/db/migrate/20150402020009_add_bio_to_user.rb
+++ b/db/migrate/20150402020009_add_bio_to_user.rb
@@ -1,0 +1,5 @@
+class AddBioToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :bio, :string
+  end
+end

--- a/db/migrate/20150402020009_add_bio_to_user.rb
+++ b/db/migrate/20150402020009_add_bio_to_user.rb
@@ -1,5 +1,0 @@
-class AddBioToUser < ActiveRecord::Migration
-  def change
-    add_column :users, :bio, :string
-  end
-end

--- a/db/migrate/20150410220259_add_bio.rb
+++ b/db/migrate/20150410220259_add_bio.rb
@@ -1,0 +1,5 @@
+class AddBio < ActiveRecord::Migration
+  def change
+    add_column :users, :bio, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150325185301) do
+ActiveRecord::Schema.define(version: 20150402020009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 20150325185301) do
     t.string   "unlocked_until_day"
     t.datetime "last_assisted_at"
     t.datetime "deactivated_at"
+    t.string   "bio"
   end
 
   add_index "users", ["cohort_id"], name: "index_users_on_cohort_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150402020009) do
+ActiveRecord::Schema.define(version: 20150410220259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,18 +79,6 @@ ActiveRecord::Schema.define(version: 20150402020009) do
     t.string   "location",   default: "Vancouver"
   end
 
-  create_table "comments", force: true do |t|
-    t.text     "content"
-    t.integer  "commentable_id"
-    t.string   "commentable_type"
-    t.integer  "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
-  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
-
   create_table "day_feedbacks", force: true do |t|
     t.string   "mood"
     t.string   "title"
@@ -119,7 +107,7 @@ ActiveRecord::Schema.define(version: 20150402020009) do
     t.string   "unlocked_until_day"
     t.datetime "last_assisted_at"
     t.datetime "deactivated_at"
-    t.string   "bio"
+    t.text     "bio"
   end
 
   add_index "users", ["cohort_id"], name: "index_users_on_cohort_id", using: :btree

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,9 +19,13 @@ describe User do
     expect(user).to be_invalid
   end
 
+  it "is able to have the bio field be empty" do
+    user = build(:user, bio: nil)
+    expect(user).to be_valid
+  end
+
   describe "#full_name" do
     it "returns a concatenation of first_name and last_name" do
-      user = create(:user)
       expect(user.full_name).to eq "#{user.first_name} #{user.last_name}"
     end
   end


### PR DESCRIPTION
Based off card 6 in the "New doing list" on Trello, I have added a user bio field for all users. This is accessible for all users on the edit page and, for students, will appear in the classmates listing page under the column "Bio."

To review this, please check my additions on the registration form referenced in the profiles edit view. Additionally, there are additions to the table on the students index view and a migration was run to add a bio column to the users table. 

This feature is fully implemented although I have not confirmed its functionality with any tests. 