### PR TITLE
Feature/161 distinguish remote students

### DIFF
--- a/app/assets/stylesheets/assistance_requests.css.scss
+++ b/app/assets/stylesheets/assistance_requests.css.scss
@@ -26,6 +26,15 @@
       font-size: 250%;
       margin: .125em 0;
     }
+    .student-remote {
+      background: $brand-danger;
+      color: white;
+      display: block;
+      font-size: 85%;
+      font-weight: bold;
+      text-align: center;
+      text-transform: uppercase;
+    }
     .student-cohort {
       margin-top: -.25em;
       .cohort-name {

--- a/app/views/assistance_requests/index.html.erb
+++ b/app/views/assistance_requests/index.html.erb
@@ -3,6 +3,9 @@
   <li>
     <div class="student-avatar">
       <img src="{{requestor.custom_avatar.thumb.url}}{{^requestor.custom_avatar.thumb.url}}{{requestor.avatar_url}}{{/requestor.custom_avatar.thumb.url}}" />
+      {{#requestor.remote}}
+      <span class="student-remote">Remote</span>
+      {{/requestor.remote}}
     </div>
     <div class="student-description">
       <h4 class="student-heading">{{requestor.first_name}} {{requestor.last_name}}</h4>
@@ -23,6 +26,9 @@
   <li>
     <div class="student-avatar">
       <img src="{{requestor.custom_avatar.thumb.url}}{{^requestor.custom_avatar.thumb.url}}{{requestor.avatar_url}}{{/requestor.custom_avatar.thumb.url}}" />
+      {{#requestor.remote}}
+      <span class="student-remote">Remote</span>
+      {{/requestor.remote}}
     </div>
     <div class="student-description">
       <h4 class="student-heading">{{requestor.first_name}} {{requestor.last_name}}</h4>
@@ -43,6 +49,9 @@
   <li>
     <div class="student-avatar">
       <img src="{{custom_avatar.thumb.url}}{{^custom_avatar.thumb.url}}{{avatar_url}}{{/custom_avatar.thumb.url}}" />
+      {{#remote}}
+      <span class="student-remote">Remote</span>
+      {{/remote}}
     </div>
     <div class="student-description">
       <h4 class="student-heading">{{first_name}} {{last_name}}</h4>
@@ -57,6 +66,9 @@
   <li class="active">
     <div class="student-avatar">
       <img src="{{assistee.custom_avatar.thumb.url}}{{^assistee.custom_avatar.thumb.url}}{{assistee.avatar_url}}{{/assistee.custom_avatar.thumb.url}}" />
+      {{#assistee.remote}}
+      <span class="student-remote">Remote</span>
+      {{/assistee.remote}}
     </div>
     <div class="student-description">
       <h4 class="student-heading">{{assistee.first_name}} {{assistee.last_name}}</h4>

--- a/db/migrate/20150425154307_add_remote_to_users.rb
+++ b/db/migrate/20150425154307_add_remote_to_users.rb
@@ -1,0 +1,5 @@
+class AddRemoteToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :remote, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150420184454) do
+ActiveRecord::Schema.define(version: 20150425154307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 20150420184454) do
     t.datetime "last_assisted_at"
     t.datetime "deactivated_at"
     t.string   "slack"
+    t.boolean  "remote",                 default: false
   end
 
   add_index "users", ["cohort_id"], name: "index_users_on_cohort_id", using: :btree


### PR DESCRIPTION
This change adds a column to the users table that distinguishes between physical and remote users. Remote users, at this point, for example, are those students (and TAs?) who are participating in the Whitehorse remote bootcamp but are technically a part of the Vancouver cohort.

This new column is exposed in the assistance request queue UI as a red banner underneath a student's avatar indicating that they are remote. Non-remote students have no banner.

This could in the future be used to determine whether a TA is "assisting remotely" so that the student would see "Teacher Name assisting (remotely)" in their assistance request button.