### PR TITLE
Feature/172 filter queue by location

### DIFF
--- a/app/assets/javascripts/assistance_requests.js.coffee
+++ b/app/assets/javascripts/assistance_requests.js.coffee
@@ -60,5 +60,17 @@ $ ->
     poll = ->
       getRequestData()
       setTimeout(poll, 3000)
-
     poll()
+
+  cohorts_locations_checkboxes = $('#cohort-locations').find('input[type=checkbox]')
+  updateCohortLocationsCookie = ->
+    selected_locations = cohorts_locations_checkboxes.filter(':checked').map(-> $(this).val()).get()
+    locations_string = encodeURIComponent(JSON.stringify(selected_locations))
+    expires = new Date()
+    expires.setFullYear(expires.getFullYear() + 1)
+    expiry_string = expires.toUTCString()
+    document.cookie = 'cohort_locations=' + locations_string + '; expires=' + expiry_string + '; path=/'
+    getRequestData()
+  cohorts_locations_checkboxes.on 'change', updateCohortLocationsCookie
+  updateCohortLocationsCookie()
+

--- a/app/assets/javascripts/assistance_requests.js.coffee
+++ b/app/assets/javascripts/assistance_requests.js.coffee
@@ -72,5 +72,4 @@ $ ->
     document.cookie = 'cohort_locations=' + locations_string + '; expires=' + expiry_string + '; path=/'
     getRequestData()
   cohorts_locations_checkboxes.on 'change', updateCohortLocationsCookie
-  updateCohortLocationsCookie()
 

--- a/app/assets/stylesheets/assistance_requests.css.scss
+++ b/app/assets/stylesheets/assistance_requests.css.scss
@@ -1,3 +1,9 @@
+#cohort-locations {
+  label {
+    display: inline-block;
+    margin: 0 .25em;
+  }
+}
 .requests-list {
   img {
     height: auto;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,8 +48,8 @@ class ApplicationController < ActionController::Base
       @cohort ||= Cohort.find_by(id: session[:cohort_id]) if session[:cohort_id]
     end
     @cohort ||= current_user.try(:cohort) # Students have a cohort
-    @cohort ||= Cohort.most_recent.first
-    @program = @cohort.program
+    @cohort ||= Cohort.most_recent.first # If any cohorts exist, use the latest
+    @program = @cohort.try(:program)
     @cohort
   end
   helper_method :cohort

--- a/app/controllers/assistance_requests_controller.rb
+++ b/app/controllers/assistance_requests_controller.rb
@@ -3,15 +3,15 @@ class AssistanceRequestsController < ApplicationController
   before_filter :teacher_required, only: [:index, :destroy, :start_assistance, :end_assistance]
 
   def index
+    locations_cookie = cookies[:cohort_locations]
+    @selected_locations = locations_cookie ? JSON.parse(locations_cookie) : []
+
     respond_to do |format|
       format.json {
-        locations_cookie = cookies[:cohort_locations]
-        locations = locations_cookie ? JSON.parse(locations_cookie) : []
-
         my_active_assistances = Assistance.assisted_by(current_user).currently_active
-        requests = AssistanceRequest.where(type: nil).open_requests.oldest_requests_first.requestor_cohort_in_locations(locations)
-        code_reviews = CodeReviewRequest.open_requests.oldest_requests_first.requestor_cohort_in_locations(locations)
-        all_students = Student.in_active_cohort.active.order_by_last_assisted_at.cohort_in_locations(locations)
+        requests = AssistanceRequest.where(type: nil).open_requests.oldest_requests_first.requestor_cohort_in_locations(@selected_locations)
+        code_reviews = CodeReviewRequest.open_requests.oldest_requests_first.requestor_cohort_in_locations(@selected_locations)
+        all_students = Student.in_active_cohort.active.order_by_last_assisted_at.cohort_in_locations(@selected_locations)
 
         res = {
           active_assistances: my_active_assistances.all.to_json(:include => {:assistee => { :include => [:cohort] }, :assistance_request => {:include => :activity_submission}}),
@@ -21,7 +21,10 @@ class AssistanceRequestsController < ApplicationController
         }
         render json: res
       }
-      format.all { render :index, layout: "assistance" }
+      format.all {
+        @all_locations = Cohort.distinct('location').pluck('location')
+        render :index, layout: "assistance"
+      }
     end
   end
 

--- a/app/controllers/assistance_requests_controller.rb
+++ b/app/controllers/assistance_requests_controller.rb
@@ -3,20 +3,23 @@ class AssistanceRequestsController < ApplicationController
   before_filter :teacher_required, only: [:index, :destroy, :start_assistance, :end_assistance]
 
   def index
-    @my_active_assistances = Assistance.assisted_by(current_user).currently_active
-    @requests = AssistanceRequest.where(type: nil).open_requests.oldest_requests_first
-    @code_reviews = CodeReviewRequest.open_requests.oldest_requests_first
-    @all_students = Student.in_active_cohort.active.order_by_last_assisted_at
-
     respond_to do |format|
       format.json {
-        @obj = {
-          active_assistances: @my_active_assistances.all.to_json(:include => {:assistee => { :include => [:cohort] }, :assistance_request => {:include => :activity_submission}}),
-          requests: @requests.all.to_json(:include => { requestor: { :include => [:cohort] } }),
-          code_reviews: @code_reviews.all.to_json(:include => { :requestor => { :include => [:cohort] }, :activity_submission => {} }),
-          all_students: @all_students.all.to_json(:include => [:cohort])
+        locations_cookie = cookies[:cohort_locations]
+        locations = locations_cookie ? JSON.parse(locations_cookie) : []
+
+        my_active_assistances = Assistance.assisted_by(current_user).currently_active
+        requests = AssistanceRequest.where(type: nil).open_requests.oldest_requests_first.requestor_cohort_in_locations(locations)
+        code_reviews = CodeReviewRequest.open_requests.oldest_requests_first.requestor_cohort_in_locations(locations)
+        all_students = Student.in_active_cohort.active.order_by_last_assisted_at.cohort_in_locations(locations)
+
+        res = {
+          active_assistances: my_active_assistances.all.to_json(:include => {:assistee => { :include => [:cohort] }, :assistance_request => {:include => :activity_submission}}),
+          requests: requests.all.to_json(:include => { requestor: { :include => [:cohort] } }),
+          code_reviews: code_reviews.all.to_json(:include => { :requestor => { :include => [:cohort] }, :activity_submission => {} }),
+          all_students: all_students.all.to_json(:include => [:cohort])
         }
-        render json: @obj
+        render json: res
       }
       format.all { render :index, layout: "assistance" }
     end

--- a/app/models/assistance_request.rb
+++ b/app/models/assistance_request.rb
@@ -54,7 +54,7 @@ class AssistanceRequest < ActiveRecord::Base
   end
 
   def position_in_queue
-    self.class.open_requests.where(type: nil).where('id < ?', id).count + 1 if open?
+    self.class.open_requests.where(type: nil).requestor_cohort_in_locations([requestor.cohort.location]).where('assistance_requests.id < ?', id).count + 1 if open?
   end
 
   private

--- a/app/models/assistance_request.rb
+++ b/app/models/assistance_request.rb
@@ -17,6 +17,13 @@ class AssistanceRequest < ActiveRecord::Base
     joins("LEFT OUTER JOIN assistances ON assistances.id = assistance_requests.assistance_id").
     where("assistance_requests.canceled_at IS NULL AND (assistances.id IS NULL OR assistances.end_at IS NULL)")
   }
+  scope :requestor_cohort_in_locations, -> (locations) {
+    if locations.is_a?(Array) && locations.length > 0
+      joins('LEFT OUTER JOIN users AS requestors ON assistance_requests.requestor_id = requestors.id').
+      joins('LEFT OUTER JOIN cohorts AS requestors_cohorts ON requestors.cohort_id = requestors_cohorts.id').
+      where('requestors_cohorts.location' => locations)
+    end
+  }
   scope :oldest_requests_first, -> { order(start_at: :asc) }
   scope :newest_requests_first, -> { order(start_at: :desc) }
   scope :requested_by, -> (user) { where(:requestor => user) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,12 @@ class User < ActiveRecord::Base
   scope :order_by_last_assisted_at, -> {
     order("last_assisted_at ASC NULLS FIRST")
   }
-
+  scope :cohort_in_locations, -> (locations) {
+    if locations.is_a?(Array) && locations.length > 0
+      joins('LEFT OUTER JOIN cohorts AS cohorts_locations ON users.cohort_id = cohorts_locations.id').
+      where('cohorts_locations.location' => locations)
+    end
+  }
   scope :active, -> {
     where(deactivated_at: nil, completed_registration: true)
   }

--- a/app/views/assistance_requests/index.html.erb
+++ b/app/views/assistance_requests/index.html.erb
@@ -1,3 +1,9 @@
+<div id="cohort-locations">
+  Cohort locations:
+  <% @all_locations.each do |location| %>
+    <label><%= check_box_tag "location_#{location}", location, @selected_locations.include?(location) %> <%= location %></label>
+  <% end %>
+</div>
 <div class="requests-list"></div>
 <script id="request_template" type="x-tmpl-mustache">
   <li>

--- a/spec/factories/assistance_requests.rb
+++ b/spec/factories/assistance_requests.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :assistance_request do
-    association :requestor, factory: :user
+    association :requestor, factory: :student
 
     factory :open_assistance_request do
       canceled_at nil

--- a/spec/factories/assistances.rb
+++ b/spec/factories/assistances.rb
@@ -2,8 +2,8 @@
 
 FactoryGirl.define do
   factory :assistance do
-    association :assistor, factory: :user
-    association :assistee, factory: :user
+    association :assistor, factory: :teacher
+    association :assistee, factory: :student
     association :assistance_request
   end
 end

--- a/spec/factories/programs.rb
+++ b/spec/factories/programs.rb
@@ -1,10 +1,7 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
 FactoryGirl.define do
-  factory :cohort do
+  factory :program do
     name { Faker::Name.name }
-    start_date { Date.current }
-    code { SecureRandom.hex(10) }
-    association :program
   end
 end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -1,7 +1,7 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
 FactoryGirl.define do
-  factory :teacher do
+  factory :teacher, parent: :user, class: Teacher do
     first_name   { Faker::Name.first_name }
     last_name    { Faker::Name.last_name }
     email        { Faker::Internet.safe_email }


### PR DESCRIPTION
Enable teachers to filter the request queue by the location of the cohort.

Also, fix code in ApplicationController that was causing tests to fail and improve test factories.

Change the behaviour of AssistanceRequest#position_in_queue to return the position in the requesting student's "local" queue. That is, their position in the queue of students whose cohorts are in the same location as their own.