### PR TITLE
Fix Menu Button To Show Bootstrap Icon Bar

### DIFF
--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -4,6 +4,9 @@ nav.navbar.navbar-inverse.navbar-fixed-top role="navigation"
     .navbar-header
       button.navbar-toggle data-target=".navbar-collapse" data-toggle="collapse" type="button"
         span.sr-only Toggle navigation
+        span.icon-bar
+        span.icon-bar
+        span.icon-bar
     .collapse.navbar-collapse
       ul.nav.navbar-nav.navbar-left
         li


### PR DESCRIPTION
Fixed the menu button on the 	nav-bar for responsive layouts to create a button that looks like ≡ on narrow browser screens. This button is displayed when the screen width is small and the nav-bar collapses. When you click on it, the nav-bar expands.